### PR TITLE
melodic compatibility

### DIFF
--- a/stomp_moveit/src/stomp_smoothing_adapter.cpp
+++ b/stomp_moveit/src/stomp_smoothing_adapter.cpp
@@ -80,20 +80,20 @@ public:
 
     // STOMP reads the seed trajectory from trajectory constraints so we need to convert the waypoints first
     const size_t seed_waypoint_count = res.trajectory_->getWayPointCount();
-    const std::vector<std::string> joint_names =
-      res.trajectory_->getFirstWayPoint().getJointModelGroup(req.group_name)->getActiveJointModelNames();
-    const size_t joint_count = joint_names.size();
+    const std::vector<std::string> variable_names =
+      res.trajectory_->getFirstWayPoint().getJointModelGroup(req.group_name)->getVariableNames();
+    const size_t variable_count = variable_names.size();
     planning_interface::MotionPlanRequest seed_req = req;
     seed_req.trajectory_constraints.constraints.clear();
     seed_req.trajectory_constraints.constraints.resize(seed_waypoint_count);
     for (size_t i = 0; i < seed_waypoint_count; ++i)
     {
-      seed_req.trajectory_constraints.constraints[i].joint_constraints.resize(joint_count);
-      for (size_t j = 0; j < joint_count; ++j)
+      seed_req.trajectory_constraints.constraints[i].joint_constraints.resize(variable_count);
+      for (size_t j = 0; j < variable_count; ++j)
       {
-        seed_req.trajectory_constraints.constraints[i].joint_constraints[j].joint_name = joint_names[j];
+        seed_req.trajectory_constraints.constraints[i].joint_constraints[j].joint_name = variable_names[j];
         seed_req.trajectory_constraints.constraints[i].joint_constraints[j].position =
-          res.trajectory_->getWayPoint(i).getVariablePosition(joint_names[j]);
+          res.trajectory_->getWayPoint(i).getVariablePosition(variable_names[j]);
       }
     }
 

--- a/stomp_moveit/src/stomp_smoothing_adapter.cpp
+++ b/stomp_moveit/src/stomp_smoothing_adapter.cpp
@@ -107,8 +107,8 @@ public:
     }
 
     // Initialize STOMP Planner
-    stomp_moveit::StompPlanner stompPlanner(req.group_name, group_config_it->second, ps->getRobotModel());
-    if(!stompPlanner.canServiceRequest(seed_req))
+    stomp_moveit::StompPlanner stomp_planner(req.group_name, group_config_it->second, ps->getRobotModel());
+    if(!stomp_planner.canServiceRequest(seed_req))
     {
       ROS_ERROR("STOMP planner unable to service request");
       res.error_code_.val = moveit_msgs::MoveItErrorCodes::FAILURE;
@@ -116,14 +116,14 @@ public:
     }
 
     // Setup Planning Context
-    stompPlanner.clear();
-    stompPlanner.setPlanningScene(ps);
-    stompPlanner.setMotionPlanRequest(seed_req);
+    stomp_planner.clear();
+    stomp_planner.setPlanningScene(ps);
+    stomp_planner.setMotionPlanRequest(seed_req);
 
     // Solve
     ROS_DEBUG("Smoothing result trajectory with STOMP");
     planning_interface::MotionPlanDetailedResponse stomp_res;
-    bool success = stompPlanner.solve(stomp_res);
+    bool success = stomp_planner.solve(stomp_res);
     if (success)
     {
       // Successful responses always contain one entry for trajectory_ and proccessing_time_

--- a/stomp_moveit/src/stomp_smoothing_adapter.cpp
+++ b/stomp_moveit/src/stomp_smoothing_adapter.cpp
@@ -52,9 +52,12 @@ class StompSmoothingAdapter : public planning_request_adapter::PlanningRequestAd
 public:
   StompSmoothingAdapter() : planning_request_adapter::PlanningRequestAdapter()
   {
+    ros::NodeHandle nh("~");
+    initialize(nh);
   }
 
-  virtual void initialize(const ros::NodeHandle& node_handle) override
+  // todo[noetic] add override again
+  virtual void initialize(const ros::NodeHandle& node_handle)
   {
     ros::NodeHandle nh(node_handle);
     if (!StompPlanner::getConfigData(nh, group_config_))


### PR DESCRIPTION
This PR adds a fallback for melodic compatibility. I planned to add an `#ifdef` but MoveIt master seems to have a lower version number than melodic-devel currently (https://github.com/ros-planning/moveit/issues/2036) ... I think in the meantime this could also be considered a feature as it would allow you to specify global parameters and then tune some in the specific pipeline ... :wink: 

Also this copies variables instead of joints as a joint might have more than one DoF and thus more than one variable. I have however no way to test something like that and I don't know if stomp will actually handle this appropriately (in the constraint it's still names `joint` ...)

This addresses all remarks by @jrgnicho in the original PR I hope